### PR TITLE
Fix long names overlapping each other

### DIFF
--- a/components/UserDelegate.qml
+++ b/components/UserDelegate.qml
@@ -110,6 +110,8 @@ Item {
             bottom: parent.bottom
             horizontalCenter: parent.horizontalCenter
         }
+        width: parent.width - 20
+        wrapMode: Text.WordWrap
         height: implicitHeight // work around stupid bug in Plasma Components that sets the height
         // width: constrainText ? parent.width : implicitWidth
         text: wrapper.name


### PR DESCRIPTION
My full name is pretty long and it overlapped with the names of the other users, I added word wrap to the labels below the avatars.